### PR TITLE
[AWS Free Tier] Change instance type from t2.micro to t3.mico

### DIFF
--- a/windows.pkr.hcl
+++ b/windows.pkr.hcl
@@ -20,7 +20,7 @@ locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 source "amazon-ebs" "firstrun-windows" {
   ami_name      = "packer-windows-demo-${local.timestamp}"
   communicator  = "winrm"
-  instance_type = "t2.micro"
+  instance_type = "t3.micro"
   region        = "${var.region}"
   source_ami_filter {
     filters = {


### PR DESCRIPTION
Done to make the sample compatible with "AWS Free Tier" that no longer supports `t2.micro` instances.

### Free Tier-compatible instance types
"AWS Free Tier" compatible instance types as of December 2025:  
<img width="767" height="341" alt="image" src="https://github.com/user-attachments/assets/709240b8-6229-4204-8f40-a45b180a04d9" />
