### PR TITLE
Upgrade sample to Windows Server 2025

### DIFF
--- a/bootstrap_win.txt
+++ b/bootstrap_win.txt
@@ -1,7 +1,8 @@
 <powershell>
 # Set administrator password
 net user Administrator SuperS3cr3t!!!!
-wmic useraccount where "name='Administrator'" set PasswordExpires=FALSE
+# Disable pasword expiry for Administrator account
+Get-WmiObject -Class Win32_UserAccount -Filter "name = 'Administrator'" | Set-WmiInstance -Arguments @{PasswordExpires = 0}
 
 # First, make sure WinRM can't be connected to
 netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=block

--- a/bootstrap_win.txt
+++ b/bootstrap_win.txt
@@ -11,14 +11,6 @@ netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" n
 winrm delete winrm/config/listener?Address=*+Transport=HTTP  2>$Null
 winrm delete winrm/config/listener?Address=*+Transport=HTTPS 2>$Null
 
-# Disable group policies which block basic authentication and unencrypted login
-
-Set-ItemProperty -Path HKLM:\Software\Policies\Microsoft\Windows\WinRM\Client -Name AllowBasic -Value 1
-Set-ItemProperty -Path HKLM:\Software\Policies\Microsoft\Windows\WinRM\Client -Name AllowUnencryptedTraffic -Value 1
-Set-ItemProperty -Path HKLM:\Software\Policies\Microsoft\Windows\WinRM\Service -Name AllowBasic -Value 1
-Set-ItemProperty -Path HKLM:\Software\Policies\Microsoft\Windows\WinRM\Service -Name AllowUnencryptedTraffic -Value 1
-
-
 # Create a new WinRM listener and configure
 winrm create winrm/config/listener?Address=*+Transport=HTTP
 winrm set winrm/config/winrs '@{MaxMemoryPerShellMB="0"}'

--- a/windows.pkr.hcl
+++ b/windows.pkr.hcl
@@ -24,7 +24,7 @@ source "amazon-ebs" "firstrun-windows" {
   region        = "${var.region}"
   source_ami_filter {
     filters = {
-      name                = "Windows_Server-2012-R2*English-64Bit-Base*"
+      name                = "Windows_Server-2025-English-Full-Base*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }


### PR DESCRIPTION
Windows 2012 is rather dated, so I propose modernizing the sample to instead use Windows 2025 as basis. ["wmic" is no longer included in Windows Server 2025](https://learn.microsoft.com/en-us/windows-server/get-started/removed-deprecated-features-windows-server?tabs=ws25). Therefore, I also needed to replace the "wmic" call with an equivalent PowerShell command for disabling password expiry. I've also simplified some of the other configuration.

I've already verified that `packer build` succeeds and it's possible to log in with RDP using the hardcoded password afterwards.

### Build log when testing the changes
```
> packer build windows.pkr.hcl
learn-packer.amazon-ebs.firstrun-windows: output will be in this color.

==> learn-packer.amazon-ebs.firstrun-windows: Prevalidating any provided VPC information
==> learn-packer.amazon-ebs.firstrun-windows: Prevalidating AMI Name: packer-windows-demo-20251217193231
==> learn-packer.amazon-ebs.firstrun-windows: Found Image ID: ami-06777e7ef7441deff
==> learn-packer.amazon-ebs.firstrun-windows: Creating temporary keypair: packer_6943054f-bc6f-0878-4888-39139e0687c1
==> learn-packer.amazon-ebs.firstrun-windows: Creating temporary security group for this instance: packer_69430551-f80b-2c0a-03d9-75f47b15938e
==> learn-packer.amazon-ebs.firstrun-windows: Authorizing access to port 5985 from [0.0.0.0/0] in the temporary security groups...
==> learn-packer.amazon-ebs.firstrun-windows: Launching a source AWS instance...
==> learn-packer.amazon-ebs.firstrun-windows: Instance ID: i-09065ad536aa6b91c
==> learn-packer.amazon-ebs.firstrun-windows: Waiting for instance (i-09065ad536aa6b91c) to become ready...
==> learn-packer.amazon-ebs.firstrun-windows: Skipping waiting for password since WinRM password set...
==> learn-packer.amazon-ebs.firstrun-windows: Using WinRM communicator to connect: 44.211.83.20
==> learn-packer.amazon-ebs.firstrun-windows: Waiting for WinRM to become available...
==> learn-packer.amazon-ebs.firstrun-windows: WinRM connected.
==> learn-packer.amazon-ebs.firstrun-windows: Connected to WinRM!
==> learn-packer.amazon-ebs.firstrun-windows: Provisioning with Powershell...
==> learn-packer.amazon-ebs.firstrun-windows: Provisioning with powershell script: C:\Users\forde\AppData\Local\Temp\powershell-provisioner228802907
==> learn-packer.amazon-ebs.firstrun-windows: HELLO NEW USER; WELCOME TO PACKER
==> learn-packer.amazon-ebs.firstrun-windows: You need to use backtick escapes when using
==> learn-packer.amazon-ebs.firstrun-windows: characters such as DOLLAR$ directly in a command
==> learn-packer.amazon-ebs.firstrun-windows: or in your own scripts.
==> learn-packer.amazon-ebs.firstrun-windows: Restarting Machine
==> learn-packer.amazon-ebs.firstrun-windows: Waiting for machine to restart...
==> learn-packer.amazon-ebs.firstrun-windows: A system shutdown is in progress.(1115)
==> learn-packer.amazon-ebs.firstrun-windows: A system shutdown is in progress.(1115)
==> learn-packer.amazon-ebs.firstrun-windows: A system shutdown is in progress.(1115)
==> learn-packer.amazon-ebs.firstrun-windows: A system shutdown is in progress.(1115)
==> learn-packer.amazon-ebs.firstrun-windows: EC2AMAZ-CNDEHAA restarted.
==> learn-packer.amazon-ebs.firstrun-windows: Machine successfully restarted, moving on
==> learn-packer.amazon-ebs.firstrun-windows: Provisioning with Powershell...
==> learn-packer.amazon-ebs.firstrun-windows: Provisioning with powershell script: ./sample_script.ps1
==> learn-packer.amazon-ebs.firstrun-windows: PACKER_BUILD_NAME is an env var Packer automatically sets for you.
==> learn-packer.amazon-ebs.firstrun-windows: ...or you can set it in your builder variables.
==> learn-packer.amazon-ebs.firstrun-windows: The default for this builder is: firstrun-windows
==> learn-packer.amazon-ebs.firstrun-windows: The PowerShell provisioner will automatically escape characters
==> learn-packer.amazon-ebs.firstrun-windows: considered special to PowerShell when it encounters them in
==> learn-packer.amazon-ebs.firstrun-windows: your environment variables or in the PowerShell elevated
==> learn-packer.amazon-ebs.firstrun-windows: username/password fields.
==> learn-packer.amazon-ebs.firstrun-windows: For example, VAR1 from our config is: A$Dollar
==> learn-packer.amazon-ebs.firstrun-windows: Likewise, VAR2 is: A`Backtick
==> learn-packer.amazon-ebs.firstrun-windows: VAR3 is: A'SingleQuote
==> learn-packer.amazon-ebs.firstrun-windows: Finally, VAR4 is: A"DoubleQuote
==> learn-packer.amazon-ebs.firstrun-windows: None of the special characters needed escaping in the template
==> learn-packer.amazon-ebs.firstrun-windows: Stopping the source instance...
==> learn-packer.amazon-ebs.firstrun-windows: Stopping instance
==> learn-packer.amazon-ebs.firstrun-windows: Waiting for the instance to stop...
==> learn-packer.amazon-ebs.firstrun-windows: Creating AMI packer-windows-demo-20251217193231 from instance i-09065ad536aa6b91c
==> learn-packer.amazon-ebs.firstrun-windows: Attaching run tags to AMI...
==> learn-packer.amazon-ebs.firstrun-windows: AMI: ami-0cc7faa6ec04059c9
==> learn-packer.amazon-ebs.firstrun-windows: Waiting for AMI to become ready...
==> learn-packer.amazon-ebs.firstrun-windows: Skipping Enable AMI deprecation...
==> learn-packer.amazon-ebs.firstrun-windows: Skipping Enable AMI deregistration protection...
==> learn-packer.amazon-ebs.firstrun-windows: Terminating the source AWS instance...
==> learn-packer.amazon-ebs.firstrun-windows: Cleaning up any extra volumes...
==> learn-packer.amazon-ebs.firstrun-windows: No volumes to clean up, skipping
==> learn-packer.amazon-ebs.firstrun-windows: Deleting temporary security group...
==> learn-packer.amazon-ebs.firstrun-windows: Deleting temporary keypair...
Build 'learn-packer.amazon-ebs.firstrun-windows' finished after 24 minutes 54 seconds.

==> Wait completed after 24 minutes 54 seconds

==> Builds finished. The artifacts of successful builds are:
--> learn-packer.amazon-ebs.firstrun-windows: AMIs were created:
us-east-1: ami-0cc7faa6ec04059c9
```